### PR TITLE
Fix date ranges/navigation for reports

### DIFF
--- a/src/entities/Report.js
+++ b/src/entities/Report.js
@@ -107,8 +107,10 @@ export default Report
 function dateRange(date, timespan) {
   const start = timespan === TIMESPAN_YEARLY ? startOfYear : startOfMonth
   const end = timespan === TIMESPAN_YEARLY ? endOfYear : endOfMonth
+  let tempDate = new Date(date);
+  tempDate.setDate(tempDate.getDate()+1);
   return {
-    start: toUtcTimestamp(start(date)),
-    end: toUtcTimestamp(end(date))
+    start: toUtcTimestamp(start(tempDate)),
+    end: toUtcTimestamp(end(tempDate))
   }
 }

--- a/src/selectors/ui/report.js
+++ b/src/selectors/ui/report.js
@@ -2,8 +2,10 @@ import Report from '../../entities/Report'
 
 export const getReport = state => state.ui.report
 export const getTimespanLabel = state => {
+  let startdate = new Date(state.ui.report.date.start);
+  startdate.setDate(startdate.getDate()+1);
   return Report.timespanLabel(
-    state.ui.report.date.start,
+    startdate,
     state.ui.report.timespan
   )
 }


### PR DESCRIPTION
There may be a better way to do it, but this was what I figured out and seemed to work.  

The range is always coming back from Dec 31 to Dec 31, so the "start" date is always in the previous year, then it subtracts a year from that which pushes it 2 years back each time.

I believe this addresses issue #14 