### PR TITLE
Update ExpenseTags.js  -Issue# 55 ' barchart in Report module not displaying correctly'

### DIFF
--- a/src/components/Report/Kind/ExpenseTags.js
+++ b/src/components/Report/Kind/ExpenseTags.js
@@ -31,7 +31,7 @@ class ExpenseTags extends React.Component {
       <ChartistGraph
         type="Bar"
         className="mt-report-expense-tags"
-        style={{ height: `${this.props.data.labels.length * 3}em` }}
+        style={{ height: `${this.props.data.labels.length * 6}em` }}
         data={this.props.data}
         options={options}
       />


### PR DESCRIPTION
Issue# 55 - barchart in Report module not displaying correctly

Made a change to height, allowing the expense tag name and chart to display correctly. (Edit change seen below)

![image](https://user-images.githubusercontent.com/40645489/101570794-fa72d880-398b-11eb-8720-ffa30f79ef84.png)



